### PR TITLE
fix: minimum version configuration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Github Application
 version: 1.7.0+32
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 
 dependency_overrides:


### PR DESCRIPTION
shared_preferences: 2.3.1 和 build_runner: ^2.4.12 都需要最低3.4.0 才能运行 