### PR TITLE
fix(readme): 修复 Star History 图表失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ provider 页面内状态管理：
 
 ## Star History Chart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CarGuo/gsy_github_app_flutter&type=Date)](https://star-history.com/#CarGuo/gsy_github_app_flutter&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CarGuo/gsy_github_app_flutter&type=Date)](https://star-history.dera.page/#CarGuo/gsy_github_app_flutter&Date)
 
 
 ![](http://img.cdn.guoshuyu.cn/thanks.jpg)

--- a/README_EN.md
+++ b/README_EN.md
@@ -349,7 +349,7 @@ Provider page state management:
 
 ## Star History Chart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CarGuo/gsy_github_app_flutter&type=Date)](https://star-history.com/#CarGuo/gsy_github_app_flutter&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CarGuo/gsy_github_app_flutter&type=Date)](https://star-history.dera.page/#CarGuo/gsy_github_app_flutter&Date)
 
 
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已失效：GitHub 的仓库数据接口限制导致图表无法正常刷新展示，影响项目简介页的可读性。

本次改动将图表地址更新为已稳定运行的替代数据源，该实现基于无 token 的数据通道，可长期稳定展示项目的 Star 趋势，帮助新访客直观了解项目热度。

已同步更新 README.md 与 README_EN.md 两份文件。